### PR TITLE
Adding configuration for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ perl:
   - "5.16"
 before_install:
   - sudo apt-get install libhunspell-1.3-0 hunspell-en-us libhunspell-dev myspell-es
+  - cpanm ExtUtils::PkgConfig
 script: "perl Makefile.PL && make disttest"


### PR DESCRIPTION
To cut a long story short, I needed to test what was the problem with your module not installing in Travis CI so I checked it locally and in my fork and realized that it needed preinstallation of ExtUtils::PkgConfig. I added this to .travis.yml and it works. You just need to sign up for Travis and then set the hook to test from there.
