### PR TITLE
change default c++ compiler to "c++"

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,7 +2,7 @@
 use ExtUtils::MakeMaker 6.52;
 use ExtUtils::PkgConfig;
 
-my $CC = $ENV{'CXX'} || 'g++';
+my $CC = $ENV{'CXX'} || 'c++';
 
 my $shlib_location = ExtUtils::PkgConfig->libs_only_l('hunspell');
 my $header_location = ExtUtils::PkgConfig->cflags_only_I('hunspell');


### PR DESCRIPTION
This tiny change implements SREZIC suggestion from https://rt.cpan.org/Public/Bug/Display.html?id=99810
It appears to work (Text::Hunspell with that fix passed "make test" on virtualboxed FreeBSD 10).
