### PR TITLE
use Alien::Hunspell instead of ExtUtils::PkgConfig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ perl:
   - "5.16"
 before_install:
   - sudo apt-get install libhunspell-1.3-0 hunspell-en-us libhunspell-dev myspell-es
-  - cpanm ExtUtils::PkgConfig
+  - cpanm Alien::Hunspell
 script: "perl Makefile.PL && make disttest"

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,13 +1,12 @@
 # Only EU::MM 6.52+ understands CONFIGURE_REQUIRES
 use ExtUtils::MakeMaker 6.52;
-use ExtUtils::PkgConfig;
+use Alien::Hunspell;
 
 my $CC = $ENV{'CXX'} || 'c++';
 
-my $shlib_location = ExtUtils::PkgConfig->libs_only_l('hunspell');
-my $header_location = ExtUtils::PkgConfig->cflags_only_I('hunspell');
+my $shlib_location = Alien::Hunspell->libs;
+my $header_location = Alien::Hunspell->cflags;
 
-if ($shlib_location ne '' && $header_location ne '') {
     WriteMakefile(
         NAME          => 'Text::Hunspell',
         VERSION_FROM  => 'Hunspell.pm',
@@ -27,13 +26,3 @@ if ($shlib_location ne '' && $header_location ne '') {
             keywords  => [ qw(hunspell spelling spell-checker text-processing) ],
         },
     );
-}
-else {
-    # By default, ExtUtils::PkgConfig provides a verbose warning about
-    # being unable to locate the pkgconfig file and such. This adds an
-    # additional comment after that output.
-    warn "\n=========================================================\n";
-    warn "NOTE: You may need to install the libhunspell-dev package\n";
-    warn "(or the equivalent on your OS).\n";
-    warn "=========================================================\n";
-}

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,7 @@ my $header_location = Alien::Hunspell->cflags;
         LD            => '$(CC)',
         CONFIGURE_REQUIRES => {
             'ExtUtils::MakeMaker' => "6.52",
-            'ExtUtils::PkgConfig' => 0,
+            'Alien::Hunspell'     => 0,
         },
         XSOPT         => '-C++',
         TYPEMAPS      => ['perlobject.map', 'typemap'],


### PR DESCRIPTION
This would resolve #3 

The documentation says that having a dictionary is required to pass the test suite, but it seemed to pass for me without one (?) unless maybe hunspell was being clever.